### PR TITLE
Bugfix/bias mitigation

### DIFF
--- a/docs/source/user_guide/fairness/fairness_metrics.rst
+++ b/docs/source/user_guide/fairness/fairness_metrics.rst
@@ -157,7 +157,7 @@ predictions and/or true labels in data comply with a particular fairness
 metric. For this example, we will take a look at the statistical parity
 metric. This metric, also known as demographic parity, measures how much
 a protected group’s outcome varies when compared to the rest of the
-population. Thus, such fairness metrics denote differences in error
+subgroups. Thus, such fairness metrics denote differences in error
 rates for different demographic groups/protected attributes in data.
 Therefore, these metrics are to be **minimized** to decrease
 discrepancies in model predictions with respect to specific groups of
@@ -176,7 +176,7 @@ available as scikit-learn compatible scorers, taking in a list of
 ``protected_attributes`` at creation and then being called with a
 ``model``, ``X``, and ``y`` on which to measure fairness. By default, the
 fairness metric will measure the *difference* between a subgroup’s
-outcome and that of the rest of the population, returning the *mean*
+outcome and that of the rest of the subgroups, returning the *mean*
 disparity over all subgroups. These two options can be changed at the
 creation of the metric, using the ``distance_measure`` and ``reduction``
 arguments, respectively.
@@ -271,7 +271,7 @@ Measure the Compliance of the True Labels of a Dataset with a Fairness Metric
 Given a dataset with some ground truth labels, we can
 check whether those true labels satisfy a particular fairness metric of
 concern. In this context, statistical parity measures the disparity of
-positive label rates between subgroups and the rest of the population.
+positive label rates between subgroups and the rest of the subgroups.
 Dataset fairness metrics are available as scikit-learn compatible
 scorers, taking in a list of ``protected_attributes`` at creation and
 then being called with a ``model``, ``X`` and ``y`` on which to measure
@@ -374,7 +374,7 @@ Note that, unlike statistical parity, we cannot compute equalized odds
 on the dataset since it is dependent to model output. However, we can
 compute other metrics on the dataset like ``Smoothed EDF``; it is
 computed as the minimal exponential deviation of positive target ratios
-comparing a subgroup to the rest of the population.
+comparing a subgroup to the rest of the subgroups.
 
 .. code:: python
 

--- a/guardian_ai/fairness/metrics/dataset.py
+++ b/guardian_ai/fairness/metrics/dataset.py
@@ -102,15 +102,19 @@ def _dataset_metric(
 
     groups = []
     scores = []
+    visited_subgroup_pairs = set()
+    # subgroup_divisions is a list of all subgroup pairs,
+    # e.g. [([{'sex': 0, 'race': 0}], [{'sex': 0, 'race': 1}]), ...]
     for unpriv_group, priv_group in subgroup_divisions:
         subgroup_metrics = BinaryLabelDatasetMetric(ds_true, unpriv_group, priv_group)
 
         score, group_repr = _get_score_group_from_metrics(
             subgroup_metrics, distance, metric, unpriv_group, priv_group, attr_idx_to_vals
         )
-
-        scores.append(score)
-        groups.append(group_repr)
+        if (group_repr[1], group_repr[0]) not in visited_subgroup_pairs:
+            scores.append(score)
+            groups.append(group_repr)
+            visited_subgroup_pairs.add(group_repr)
 
     return reduction(groups, scores)
 

--- a/guardian_ai/fairness/metrics/dataset.py
+++ b/guardian_ai/fairness/metrics/dataset.py
@@ -76,7 +76,7 @@ def _dataset_metric(
         Possible values are:
             * ``'max'``: Returns the maximal value among all subgroup metrics.
             * ``'mean'``: Returns the mean over all subgroup metrics.
-            * ``None``: Returns a ``{subgroup: subgroup_metric, ...}`` dict.
+            * ``None``: Returns a ``{subgroup_pair: subgroup_pair_metric, ...}`` dict.
     allow_distance_measure_none : bool
         Whether or not to allow ``distance_measure`` to be set
         to ``None``.
@@ -102,11 +102,11 @@ def _dataset_metric(
 
     groups = []
     scores = []
-    for unpriv_group, priv_groups in subgroup_divisions:
-        subgroup_metrics = BinaryLabelDatasetMetric(ds_true, unpriv_group, priv_groups)
+    for unpriv_group, priv_group in subgroup_divisions:
+        subgroup_metrics = BinaryLabelDatasetMetric(ds_true, unpriv_group, priv_group)
 
         score, group_repr = _get_score_group_from_metrics(
-            subgroup_metrics, distance, metric, unpriv_group, attr_idx_to_vals
+            subgroup_metrics, distance, metric, unpriv_group, priv_group, attr_idx_to_vals
         )
 
         scores.append(score)
@@ -143,7 +143,7 @@ class _DatasetFairnessScorer(_FairnessScorer):
         Possible values are:
             * ``'max'``: Returns the maximal value among all subgroup metrics.
             * ``'mean'``: Returns the mean over all subgroup metrics.
-            * ``None``: Returns a ``{subgroup: subgroup_metric, ...}`` dict.
+            * ``None``: Returns a ``{subgroup_pair: subgroup_pair_metric, ...}`` dict.
     allow_distance_measure_none : bool
         Whether or not to allow ``distance_measure`` to be set to ``None``.
     """
@@ -276,7 +276,7 @@ class DatasetStatisticalParityScorer(_DatasetFairnessScorer):
 
             * ``'max'``: Returns the maximal value among all subgroup metrics.
             * ``'mean'``: Returns the mean over all subgroup metrics.
-            * ``None``: Returns a ``{subgroup: subgroup_metric, ...}`` dict.
+            * ``None``: Returns a ``{subgroup_pair: subgroup_pair_metric, ...}`` dict.
 
 
     References
@@ -339,7 +339,7 @@ def dataset_statistical_parity(
 
             * ``'max'``: Returns the maximal value among all subgroup metrics.
             * ``'mean'``: Returns the mean over all subgroup metrics.
-            * ``None``: Returns a ``{subgroup: subgroup_metric, ...}`` dict.
+            * ``None``: Returns a ``{subgroup_pair: subgroup_pair_metric, ...}`` dict.
 
     Examples
     --------

--- a/guardian_ai/fairness/metrics/model.py
+++ b/guardian_ai/fairness/metrics/model.py
@@ -64,10 +64,10 @@ def _model_metric(
         Name of the base metric to be called.
     distance_measure : str or None
         Determines the distance used to compare a subgroup's metric
-        against the rest of subgroups. Possible values are:
+        against the rest of the subgroups. Possible values are:
 
-            * ``'ratio'``: Uses ``(subgroup_val / rest_of_pop_val)``. Inverted to always be >= 1 if needed.
-            * ``'diff'``: Uses ``| subgroup_val - rest_of_pop_val |``.
+            * ``'ratio'``: Uses ``(subgroup1_val / subgroup2_val)``. Inverted to always be >= 1 if needed.
+            * ``'diff'``: Uses ``| subgroup1_val - subgroup2_val |``.
             Only allowed if `allow_distance_measure_none` is set to True
     reduction : str or None
         Determines how to reduce scores on all subgroups to
@@ -146,10 +146,10 @@ class _ModelFairnessScorer(_FairnessScorer):
         Name of the base metric to be called.
     distance_measure : str or None, default='diff'
         Determines the distance used to compare a subgroup's metric against
-        the rest of subgroups. Possible values are:
+        the rest of the subgroups. Possible values are:
 
-            * ``'ratio'``: Uses ``(subgroup_val / rest_of_pop_val)``. Inverted to always be >= 1 if needed.
-            * ``'diff'``: Uses ``| subgroup_val - rest_of_pop_val |``.
+            * ``'ratio'``: Uses ``(subgroup1_val / subgroup2_val)``. Inverted to always be >= 1 if needed.
+            * ``'diff'``: Uses ``| subgroup1_val - subgroup2_val |``.
 
     reduction : str or None, default='mean'
         Determines how to reduce scores on all subgroup pairs to a single output.
@@ -256,7 +256,7 @@ class ModelStatisticalParityScorer(_ModelFairnessScorer):  # noqa: D412
     Perfect score
         A perfect score for this metric means that the model does not predict
         positively any of the subgroups at a different rate than it does for the
-        rest of subgroups. For example, if the protected attributes are race
+        rest of the subgroups. For example, if the protected attributes are race
         and sex, then a perfect statistical parity would mean that all combinations
         of values for race and sex have identical ratios of positive predictions.
         Perfect values are:
@@ -272,10 +272,10 @@ class ModelStatisticalParityScorer(_ModelFairnessScorer):  # noqa: D412
         values are considered as subgroups.
     distance_measure : str, default='diff'
         Determines the distance used to compare a subgroup's metric against
-        the rest of subgroups. Possible values are:
+        the rest of the subgroups. Possible values are:
 
-            * ``'ratio'``: Uses ``(subgroup_val / rest_of_pop_val)``. Inverted to always be >= 1 if needed.
-            * ``'diff'``: Uses ``| subgroup_val - rest_of_pop_val |``.
+            * ``'ratio'``: Uses ``(subgroup1_val / subgroup2_val)``. Inverted to always be >= 1 if needed.
+            * ``'diff'``: Uses ``| subgroup1_val - subgroup2_val |``.
 
     reduction : str, default='mean'
         Determines how to reduce scores on all subgroups to a single output.
@@ -398,10 +398,10 @@ def model_statistical_parity(
         Dataframe containing protected attributes for each instance.
     distance_measure : str, default='diff'
         Determines the distance used to compare a subgroup's metric against
-        the rest of subgroups. Possible values are:
+        the rest of the subgroups. Possible values are:
 
-            * ``'ratio'``: Uses ``(subgroup_val / rest_of_pop_val)``. Inverted to always be >= 1 if needed.
-            * ``'diff'``: Uses ``| subgroup_val - rest_of_pop_val |``.
+            * ``'ratio'``: Uses ``(subgroup1_val / subgroup2_val)``. Inverted to always be >= 1 if needed.
+            * ``'diff'``: Uses ``| subgroup1_val - subgroup2_val |``.
 
     reduction : str or None, default='mean'
         Determines how to reduce scores on all subgroups to a single output.
@@ -465,7 +465,7 @@ class TruePositiveRateScorer(_ModelFairnessScorer):
     all subgroup pairs (also known as equal opportunity).
 
     For each subgroup, the disparity is measured by comparing the true positive
-    rate on instances of a subgroup against the rest of subgroups.
+    rate on instances of a subgroup against the rest of the subgroups.
 
     True Positive Rate [1] (also known as TPR, recall, or sensitivity) is
     calculated as TP / (TP + FN), where TP and FN are the number of true
@@ -475,7 +475,7 @@ class TruePositiveRateScorer(_ModelFairnessScorer):
     Perfect score
         A perfect score for this metric means that the model does not correctly
         predict the positive class for any of the subgroups more often than it
-        does for the rest of subgroups. For example, if the protected
+        does for the rest of the subgroups. For example, if the protected
         attributes are race and sex, then a perfect true positive rate disparity
         would mean that all combinations of values for race and sex have
         identical true positive rates. Perfect values are:
@@ -491,10 +491,10 @@ class TruePositiveRateScorer(_ModelFairnessScorer):
         values are considered as subgroups.
     distance_measure : str, default='diff'
         Determines the distance used to compare a subgroup's metric against
-        the rest of subgroups. Possible values are:
+        the rest of the subgroups. Possible values are:
 
-            * ``'ratio'``: Uses ``(subgroup_val / rest_of_pop_val)``. Inverted to always be >= 1 if needed.
-            * ``'diff'``: Uses ``| subgroup_val - rest_of_pop_val |``.
+            * ``'ratio'``: Uses ``(subgroup1_val / subgroup2_val)``. Inverted to always be >= 1 if needed.
+            * ``'diff'``: Uses ``| subgroup1_val - subgroup2_val |``.
 
     reduction : str or None, default='mean'
         Determines how to reduce scores on all subgroups to a single output.
@@ -556,10 +556,10 @@ def true_positive_rate(
         Dataframe containing protected attributes for each instance.
     distance_measure : str, default='diff'
         Determines the distance used to compare a subgroup's metric against
-        the rest of subgroups. Possible values are:
+        the rest of the subgroups. Possible values are:
 
-            * ``'ratio'``: Uses ``(subgroup_val / rest_of_pop_val)``. Inverted to always be >= 1 if needed.
-            * ``'diff'``: Uses ``| subgroup_val - rest_of_pop_val |``.
+            * ``'ratio'``: Uses ``(subgroup1_val / subgroup2_val)``. Inverted to always be >= 1 if needed.
+            * ``'diff'``: Uses ``| subgroup1_val - subgroup2_val |``.
     reduction : str or None, default='mean'
         Determines how to reduce scores on all subgroups to a single output.
         Possible values are:
@@ -599,7 +599,7 @@ class FalsePositiveRateScorer(_ModelFairnessScorer):
     Measures the disparity of a model's false positive rate between all subgroup pairs.
 
     For each subgroup, the disparity is measured by comparing the false
-    positive rate on instances of a subgroup against the rest of subgroups.
+    positive rate on instances of a subgroup against the rest of the subgroups.
 
     False Positive Rate [1] (also known as FPR or fall-out) is calculated as
     FP / (FP + TN), where FP and TN are the number of false positives and
@@ -608,7 +608,7 @@ class FalsePositiveRateScorer(_ModelFairnessScorer):
     Perfect score
         A perfect score for this metric means that the model does not incorrectly
         predict the positive class for any of the subgroups more often than it
-        does for the rest of subgroups. For example, if the protected
+        does for the rest of the subgroups. For example, if the protected
         attributes are race and sex, then a perfect false positive rate disparity
         would mean that all combinations of values for race and sex have identical
         false positive rates. Perfect values are:
@@ -624,10 +624,10 @@ class FalsePositiveRateScorer(_ModelFairnessScorer):
         values are considered as subgroups.
     distance_measure : str, default='diff'
         Determines the distance used to compare a subgroup's metric against
-        the rest of subgroups. Possible values are:
+        the rest of the subgroups. Possible values are:
 
-            * ``'ratio'``: Uses ``(subgroup_val / rest_of_pop_val)``. Inverted to always be >= 1 if needed.
-            * ``'diff'``: Uses ``| subgroup_val - rest_of_pop_val |``.
+            * ``'ratio'``: Uses ``(subgroup1_val / subgroup2_val)``. Inverted to always be >= 1 if needed.
+            * ``'diff'``: Uses ``| subgroup1_val - subgroup2_val |``.
 
     reduction : str or None, default='mean'
         Determines how to reduce scores on all subgroups to a single output.
@@ -689,10 +689,10 @@ def false_positive_rate(
         Dataframe containing protected attributes for each instance.
     distance_measure : str, default='diff'
         Determines the distance used to compare a subgroup's metric against
-        the rest of subgroups. Possible values are:
+        the rest of the subgroups. Possible values are:
 
-            * ``'ratio'``: Uses ``(subgroup_val / rest_of_pop_val)``. Inverted to always be >= 1 if needed.
-            * ``'diff'``: Uses ``| subgroup_val - rest_of_pop_val |``.
+            * ``'ratio'``: Uses ``(subgroup1_val / subgroup2_val)``. Inverted to always be >= 1 if needed.
+            * ``'diff'``: Uses ``| subgroup1_val - subgroup2_val |``.
 
     reduction : str or None, default='mean'
         Determines how to reduce scores on all subgroups to a single output.
@@ -733,7 +733,7 @@ class FalseNegativeRateScorer(_ModelFairnessScorer):
     Measures the disparity of a model's false negative rate between all subgroup pairs.
 
     For each subgroup, the disparity is measured by comparing the false
-    negative rate on instances of a subgroup against the rest of subgroups.
+    negative rate on instances of a subgroup against the rest of the subgroups.
 
     False Negative Rate [1] (also known as FNR or miss rate) is calculated as
     FN / (FN + TP), where FN and TP are the number of false negatives and
@@ -742,7 +742,7 @@ class FalseNegativeRateScorer(_ModelFairnessScorer):
     Perfect score
         A perfect score for this metric means that the model does not incorrectly
         predict the negative class for any of the subgroups more often than it
-        does for the rest of subgroups. For example, if the protected
+        does for the rest of the subgroups. For example, if the protected
         attributes are race and sex, then a perfect false negative rate disparity
         would mean that all combinations of values for race and sex have identical
         false negative rates. Perfect values are:
@@ -758,10 +758,10 @@ class FalseNegativeRateScorer(_ModelFairnessScorer):
         values are considered as subgroups.
     distance_measure : str, default='diff'
         Determines the distance used to compare a subgroup's metric against
-        the rest of subgroups. Possible values are:
+        the rest of the subgroups. Possible values are:
 
-            * ``'ratio'``: Uses ``(subgroup_val / rest_of_pop_val)``. Inverted to always be >= 1 if needed.
-            * ``'diff'``: Uses ``| subgroup_val - rest_of_pop_val |``.
+            * ``'ratio'``: Uses ``(subgroup1_val / subgroup2_val)``. Inverted to always be >= 1 if needed.
+            * ``'diff'``: Uses ``| subgroup1_val - subgroup2_val |``.
 
     reduction : str or None, default='mean'
         Determines how to reduce scores on all subgroups to a single output.
@@ -823,10 +823,10 @@ def false_negative_rate(
         Dataframe containing protected attributes for each instance.
     distance_measure : str, default='diff'
         Determines the distance used to compare a subgroup's metric against
-        the rest of subgroups. Possible values are:
+        the rest of the subgroups. Possible values are:
 
-            * ``'ratio'``: Uses ``(subgroup_val / rest_of_pop_val)``. Inverted to always be >= 1 if needed.
-            * ``'diff'``: Uses ``| subgroup_val - rest_of_pop_val |``.
+            * ``'ratio'``: Uses ``(subgroup1_val / subgroup2_val)``. Inverted to always be >= 1 if needed.
+            * ``'diff'``: Uses ``| subgroup1_val - subgroup2_val |``.
 
     reduction : str or None, default='mean'
         Determines how to reduce scores on all subgroups to a single output.
@@ -867,7 +867,7 @@ class FalseOmissionRateScorer(_ModelFairnessScorer):
     Measures the disparity of a model's false omission rate between all subgroup pairs.
 
     For each subgroup, the disparity is measured by comparing the false
-    omission rate on instances of a subgroup against the rest of subgroups.
+    omission rate on instances of a subgroup against the rest of the subgroups.
 
     False Omission Rate (also known as FOR) is calculated as
     FN / (FN + TN), where FN and TN are the number of false negatives and
@@ -876,7 +876,7 @@ class FalseOmissionRateScorer(_ModelFairnessScorer):
     Perfect score
         A perfect score for this metric means that the model does not make more
         mistakes on the negative class for any of the subgroups more often than it
-        does for the rest of subgroups. For example, if the protected
+        does for the rest of the subgroups. For example, if the protected
         attributes are race and sex, then a perfect false omission rate disparity
         would mean that all combinations of values for race and sex have identical
         false omission rates. Perfect values are:
@@ -892,10 +892,10 @@ class FalseOmissionRateScorer(_ModelFairnessScorer):
         values are considered as subgroups.
     distance_measure : str, default='diff'
         Determines the distance used to compare a subgroup's metric against
-        the rest of subgroups. Possible values are:
+        the rest of the subgroups. Possible values are:
 
-            * ``'ratio'``: Uses ``(subgroup_val / rest_of_pop_val)``. Inverted to always be >= 1 if needed.
-            * ``'diff'``: Uses ``| subgroup_val - rest_of_pop_val |``.
+            * ``'ratio'``: Uses ``(subgroup1_val / subgroup2_val)``. Inverted to always be >= 1 if needed.
+            * ``'diff'``: Uses ``| subgroup1_val - subgroup2_val |``.
 
     reduction : str or None, default='mean'
         Determines how to reduce scores on all subgroups to a single output.
@@ -951,10 +951,10 @@ def false_omission_rate(
         Dataframe containing protected attributes for each instance.
     distance_measure : str, default='diff'
         Determines the distance used to compare a subgroup's metric against
-        the rest of subgroups. Possible values are:
+        the rest of the subgroups. Possible values are:
 
-            * ``'ratio'``: Uses ``(subgroup_val / rest_of_pop_val)``. Inverted to always be >= 1 if needed.
-            * ``'diff'``: Uses ``| subgroup_val - rest_of_pop_val |``.
+            * ``'ratio'``: Uses ``(subgroup1_val / subgroup2_val)``. Inverted to always be >= 1 if needed.
+            * ``'diff'``: Uses ``| subgroup1_val - subgroup2_val |``.
 
     reduction : str or None, default='mean'
         Determines how to reduce scores on all subgroups to a single output.
@@ -996,7 +996,7 @@ class FalseDiscoveryRateScorer(_ModelFairnessScorer):
 
     For each subgroup, the disparity is measured by comparing the false
     discovery rate on instances of a subgroup against the rest of the
-    population.
+    subgroups.
 
     False Discovery Rate (also known as FDR) is calculated as
     FP / (FP + TP), where FP and TP are the number of false positives and
@@ -1005,7 +1005,7 @@ class FalseDiscoveryRateScorer(_ModelFairnessScorer):
     Perfect score
         A perfect score for this metric means that the model does not make more
         mistakes on the positive class for any of the subgroups more often than it
-        does for the rest of subgroups. For example, if the protected
+        does for the rest of the subgroups. For example, if the protected
         attributes are race and sex, then a perfect false discovery rate disparity
         would mean that all combinations of values for race and sex have identical
         false discovery rates. Perfect values are:
@@ -1021,10 +1021,10 @@ class FalseDiscoveryRateScorer(_ModelFairnessScorer):
         values are considered as subgroups.
     distance_measure : str, default='diff'
         Determines the distance used to compare a subgroup's metric against
-        the rest of subgroups. Possible values are:
+        the rest of the subgroups. Possible values are:
 
-            * ``'ratio'``: Uses ``(subgroup_val / rest_of_pop_val)``. Inverted to always be >= 1 if needed.
-            * ``'diff'``: Uses ``| subgroup_val - rest_of_pop_val |``.
+            * ``'ratio'``: Uses ``(subgroup1_val / subgroup2_val)``. Inverted to always be >= 1 if needed.
+            * ``'diff'``: Uses ``| subgroup1_val - subgroup2_val |``.
 
     reduction : str, default='mean'
         Determines how to reduce scores on all subgroups to a single output.
@@ -1080,10 +1080,10 @@ def false_discovery_rate(
         Dataframe containing protected attributes for each instance.
     distance_measure : str, default='diff'
         Determines the distance used to compare a subgroup's metric against
-        the rest of subgroups. Possible values are:
+        the rest of the subgroups. Possible values are:
 
-            * ``'ratio'``: Uses ``(subgroup_val / rest_of_pop_val)``. Inverted to always be >= 1 if needed.
-            * ``'diff'``: Uses ``| subgroup_val - rest_of_pop_val |``.
+            * ``'ratio'``: Uses ``(subgroup1_val / subgroup2_val)``. Inverted to always be >= 1 if needed.
+            * ``'diff'``: Uses ``| subgroup1_val - subgroup2_val |``.
 
     reduction : str or None, default='mean'
         Determines how to reduce scores on all subgroups to a single output.
@@ -1124,7 +1124,7 @@ class ErrorRateScorer(_ModelFairnessScorer):
     Measures the disparity of a model's error rate between all subgroup pairs.
 
     For each subgroup, the disparity is measured by comparing the error rate on
-    instances of a subgroup against the rest of subgroups.
+    instances of a subgroup against the rest of the subgroups.
 
     Error Rate (also known as inaccuracy) is calculated as
     (FP + FN) / N, where FP and FN are the number of false positives and
@@ -1134,7 +1134,7 @@ class ErrorRateScorer(_ModelFairnessScorer):
     Perfect score
         A perfect score for this metric means that the model does not make more
         mistakes for any of the subgroups more often than it
-        does for the rest of subgroups. For example, if the protected
+        does for the rest of the subgroups. For example, if the protected
         attributes are race and sex, then a perfect error rate disparity would
         mean that all combinations of values for race and sex have identical
         error rates. Perfect values are:
@@ -1150,10 +1150,10 @@ class ErrorRateScorer(_ModelFairnessScorer):
         values are considered as subgroups.
     distance_measure : str, default='diff'
         Determines the distance used to compare a subgroup's metric against
-        the rest of subgroups. Possible values are:
+        the rest of the subgroups. Possible values are:
 
-            * ``'ratio'``: Uses ``(subgroup_val / rest_of_pop_val)``. Inverted to always be >= 1 if needed.
-            * ``'diff'``: Uses ``| subgroup_val - rest_of_pop_val |``.
+            * ``'ratio'``: Uses ``(subgroup1_val / subgroup2_val)``. Inverted to always be >= 1 if needed.
+            * ``'diff'``: Uses ``| subgroup1_val - subgroup2_val |``.
 
     reduction : str or None, default='mean'
         Determines how to reduce scores on all subgroups to a single output.
@@ -1209,10 +1209,10 @@ def error_rate(
         Dataframe containing protected attributes for each instance.
     distance_measure : str, default='diff'
         Determines the distance used to compare a subgroup's metric against
-        the rest of subgroups. Possible values are:
+        the rest of the subgroups. Possible values are:
 
-            * ``'ratio'``: Uses ``(subgroup_val / rest_of_pop_val)``. Inverted to always be >= 1 if needed.
-            * ``'diff'``: Uses ``| subgroup_val - rest_of_pop_val |``.
+            * ``'ratio'``: Uses ``(subgroup1_val / subgroup2_val)``. Inverted to always be >= 1 if needed.
+            * ``'diff'``: Uses ``| subgroup1_val - subgroup2_val |``.
 
     reduction : str or None, default='mean'
         Determines how to reduce scores on all subgroups to a single output.
@@ -1251,10 +1251,10 @@ def error_rate(
 class EqualizedOddsScorer(_ModelFairnessScorer):
     """
     Measures the disparity of a model's true positive and false positive rates
-    between subgroups and the rest of subgroups.
+    between subgroups and the rest of the subgroups.
 
     The disparity is measured by comparing the true positive and false positive
-    rates on instances of a subgroup against the rest of subgroups.
+    rates on instances of a subgroup against the rest of the subgroups.
 
     True Positive Rate (also known as TPR, recall, or sensitivity) is
     calculated as TP / (TP + FN), where TP and FN are the number of true
@@ -1265,11 +1265,11 @@ class EqualizedOddsScorer(_ModelFairnessScorer):
     true negatives, respectively.
 
     Equalized Odds [1] is computed by taking the maximum distance between
-    TPR and FPR for a subgroup against the rest of subgroups.
+    TPR and FPR for a subgroup against the rest of the subgroups.
 
     Perfect score
         A perfect score for this metric means that the model has the same TPR and
-        FPR when comparing a subgroup to the rest of subgroups. For example,
+        FPR when comparing a subgroup to the rest of the subgroups. For example,
         if the protected attributes are race and sex, then a perfect
         Equalized Odds disparity would mean that all combinations of values for
         race and sex have identical TPR and FPR. Perfect values are:
@@ -1285,10 +1285,10 @@ class EqualizedOddsScorer(_ModelFairnessScorer):
         values are considered as subgroups.
     distance_measure : str, default='diff'
         Determines the distance used to compare a subgroup's metric against
-        the rest of subgroups. Possible values are:
+        the rest of the subgroups. Possible values are:
 
-            * ``'ratio'``: Uses ``(subgroup_val / rest_of_pop_val)``. Inverted to always be >= 1 if needed.
-            * ``'diff'``: Uses ``| subgroup_val - rest_of_pop_val |``.
+            * ``'ratio'``: Uses ``(subgroup1_val / subgroup2_val)``. Inverted to always be >= 1 if needed.
+            * ``'diff'``: Uses ``| subgroup1_val - subgroup2_val |``.
 
     reduction : str or None, default='mean'
         Determines how to reduce scores on all subgroups to a single output.
@@ -1337,7 +1337,7 @@ def equalized_odds(
 ):
     """
     Measures the disparity of a model's true positive and false positive rates
-    between subgroups and the rest of subgroups.
+    between subgroups and the rest of the subgroups.
 
     For more details, refer to :class:`.EqualizedOddsScorer`.
 
@@ -1351,10 +1351,10 @@ def equalized_odds(
         Dataframe containing protected attributes for each instance.
     distance_measure : str, default='diff'
         Determines the distance used to compare a subgroup's metric against
-        the rest of subgroups. Possible values are:
+        the rest of the subgroups. Possible values are:
 
-            * ``'ratio'``: Uses ``(subgroup_val / rest_of_pop_val)``. Inverted to always be >= 1 if needed.
-            * ``'diff'``: Uses ``| subgroup_val - rest_of_pop_val |``.
+            * ``'ratio'``: Uses ``(subgroup1_val / subgroup2_val)``. Inverted to always be >= 1 if needed.
+            * ``'diff'``: Uses ``| subgroup1_val - subgroup2_val |``.
 
     reduction : str or None, default='mean'
         Determines how to reduce scores on all subgroups to a single output.
@@ -1410,12 +1410,12 @@ class TheilIndexScorer(_ModelFairnessScorer):
 
     Intuitively, the Theil Index can be thought of as a measure of the
     divergence between a subgroup's different error distributions (i.e. false
-    positives and false negatives) against the rest of subgroups.
+    positives and false negatives) against the rest of the subgroups.
 
     Perfect score
         The perfect score for this metric is 0, meaning that the model does not
         have a different error distribution for any subgroup when compared to the
-        rest of subgroups. For example, if the protected attributes are
+        rest of the subgroups. For example, if the protected attributes are
         race and sex, then a perfect Theil Index disparity would mean that all
         combinations of values for race and sex have identical error
         distributions.
@@ -1428,10 +1428,10 @@ class TheilIndexScorer(_ModelFairnessScorer):
         values are considered as subgroups.
     distance_measure : str or None, default=None
         Determines the distance used to compare a subgroup's metric against
-        the rest of subgroups. Possible values are:
+        the rest of the subgroups. Possible values are:
 
-            * ``'ratio'``: Uses ``(subgroup_val / rest_of_pop_val)``. Inverted to always be >= 1 if needed.
-            * ``'diff'``: Uses ``| subgroup_val - rest_of_pop_val |``.
+            * ``'ratio'``: Uses ``(subgroup1_val / subgroup2_val)``. Inverted to always be >= 1 if needed.
+            * ``'diff'``: Uses ``| subgroup1_val - subgroup2_val |``.
     reduction : str or None, default='mean'
         Determines how to reduce scores on all subgroups to a single output.
         Possible values are:
@@ -1494,10 +1494,10 @@ def theil_index(
         Dataframe containing protected attributes for each instance.
     distance_measure : str or None, default=None
         Determines the distance used to compare a subgroup's metric against
-        the rest of subgroups. Possible values are:
+        the rest of the subgroups. Possible values are:
 
-            * ``'ratio'``: Uses ``(subgroup_val / rest_of_pop_val)``. Inverted to always be >= 1 if needed.
-            * ``'diff'``: Uses ``| subgroup_val - rest_of_pop_val |``.
+            * ``'ratio'``: Uses ``(subgroup1_val / subgroup2_val)``. Inverted to always be >= 1 if needed.
+            * ``'diff'``: Uses ``| subgroup1_val - subgroup2_val |``.
 
     reduction : str or None, default='mean'
         Determines how to reduce scores on all subgroups to a single output.

--- a/guardian_ai/fairness/metrics/model.py
+++ b/guardian_ai/fairness/metrics/model.py
@@ -75,7 +75,7 @@ def _model_metric(
 
             * ``'max'``: Returns the maximal value among all subgroup metrics.
             * ``'mean'``: Returns the mean over all subgroup metrics.
-            * ``None``: Returns a ``{subgroup: subgroup_metric, ...}`` dict.
+            * ``None``: Returns a ``{subgroup_pair: subgroup_pair_metric, ...}`` dict.
     allow_y_true_none : bool
         Whether or not to allow `y_true` to be set to ``None``.
     allow_distance_measure_none : bool
@@ -119,7 +119,7 @@ def _model_metric(
         )
 
         score, unpriv_group_repr = _get_score_group_from_metrics(
-            subgroup_metrics, distance, metric, unpriv_group, attr_idx_to_vals
+            subgroup_metrics, distance, metric, unpriv_group, priv_group, attr_idx_to_vals
         )
 
         scores.append(score)
@@ -157,7 +157,7 @@ class _ModelFairnessScorer(_FairnessScorer):
 
             * ``'max'``: Returns the maximal value among all subgroup metrics.
             * ``'mean'``: Returns the mean over all subgroup metrics.
-            * ``None``: Returns a ``{subgroup: subgroup_metric, ...}`` dict.
+            * ``None``: Returns a ``{subgroup_pair: subgroup_pair_metric, ...}`` dict.
 
     allow_distance_measure_none : bool, default=True
         Whether or not to allow ``distance_measure`` to be set to ``None``.
@@ -283,7 +283,7 @@ class ModelStatisticalParityScorer(_ModelFairnessScorer):  # noqa: D412
 
             * ``'max'``: Returns the maximal value among all subgroup metrics.
             * ``'mean'``: Returns the mean over all subgroup metrics.
-            * ``None``: Returns a ``{subgroup: subgroup_metric, ...}`` dict.
+            * ``None``: Returns a ``{subgroup_pair: subgroup_pair_metric, ...}`` dict.
 
 
     References
@@ -409,7 +409,7 @@ def model_statistical_parity(
 
             * ``'max'``: Returns the maximal value among all subgroup metrics.
             * ``'mean'``: Returns the mean over all subgroup metrics.
-            * ``None``: Returns a ``{subgroup: subgroup_metric, ...}`` dict.
+            * ``None``: Returns a ``{subgroup_pair: subgroup_pair_metric, ...}`` dict.
 
     Returns
     -------
@@ -502,7 +502,7 @@ class TruePositiveRateScorer(_ModelFairnessScorer):
 
             * ``'max'``: Returns the maximal value among all subgroup metrics.
             * ``'mean'``: Returns the mean over all subgroup metrics.
-            * ``None``: Returns a ``{subgroup: subgroup_metric, ...}`` dict.
+            * ``None``: Returns a ``{subgroup_pair: subgroup_pair_metric, ...}`` dict.
 
     References
     ----------
@@ -566,7 +566,7 @@ def true_positive_rate(
 
             * ``'max'``: Returns the maximal value among all subgroup metrics.
             * ``'mean'``: Returns the mean over all subgroup metrics.
-            * ``None``: Returns a ``{subgroup: subgroup_metric, ...}`` dict.
+            * ``None``: Returns a ``{subgroup_pair: subgroup_pair_metric, ...}`` dict.
 
     Returns
     -------
@@ -635,7 +635,7 @@ class FalsePositiveRateScorer(_ModelFairnessScorer):
 
             * ``'max'``: Returns the maximal value among all subgroup metrics.
             * ``'mean'``: Returns the mean over all subgroup metrics.
-            * ``None``: Returns a ``{subgroup: subgroup_metric, ...}`` dict.
+            * ``None``: Returns a ``{subgroup_pair: subgroup_pair_metric, ...}`` dict.
 
     References
     ----------
@@ -700,7 +700,7 @@ def false_positive_rate(
 
             * ``'max'``: Returns the maximal value among all subgroup metrics.
             * ``'mean'``: Returns the mean over all subgroup metrics.
-            * ``None``: Returns a ``{subgroup: subgroup_metric, ...}`` dict.
+            * ``None``: Returns a ``{subgroup_pair: subgroup_pair_metric, ...}`` dict.
 
     Returns
     -------
@@ -769,7 +769,7 @@ class FalseNegativeRateScorer(_ModelFairnessScorer):
 
             * ``'max'``: Returns the maximal value among all subgroup metrics.
             * ``'mean'``: Returns the mean over all subgroup metrics.
-            * ``None``: Returns a ``{subgroup: subgroup_metric, ...}`` dict.
+            * ``None``: Returns a ``{subgroup_pair: subgroup_pair_metric, ...}`` dict.
 
     References
     ----------
@@ -834,7 +834,7 @@ def false_negative_rate(
 
             * ``'max'``: Returns the maximal value among all subgroup metrics.
             * ``'mean'``: Returns the mean over all subgroup metrics.
-            * ``None``: Returns a ``{subgroup: subgroup_metric, ...}`` dict.
+            * ``None``: Returns a ``{subgroup_pair: subgroup_pair_metric, ...}`` dict.
 
     Returns
     -------
@@ -903,7 +903,7 @@ class FalseOmissionRateScorer(_ModelFairnessScorer):
 
             * ``'max'``: Returns the maximal value among all subgroup metrics.
             * ``'mean'``: Returns the mean over all subgroup metrics.
-            * ``None``: Returns a ``{subgroup: subgroup_metric, ...}`` dict.
+            * ``None``: Returns a ``{subgroup_pair: subgroup_pair_metric, ...}`` dict.
 
     Examples
     --------
@@ -962,7 +962,7 @@ def false_omission_rate(
 
             * ``'max'``: Returns the maximal value among all subgroup metrics.
             * ``'mean'``: Returns the mean over all subgroup metrics.
-            * ``None``: Returns a ``{subgroup: subgroup_metric, ...}`` dict.
+            * ``None``: Returns a ``{subgroup_pair: subgroup_pair_metric, ...}`` dict.
 
     Returns
     -------
@@ -1032,7 +1032,7 @@ class FalseDiscoveryRateScorer(_ModelFairnessScorer):
 
             * ``'max'``: Returns the maximal value among all subgroup metrics.
             * ``'mean'``: Returns the mean over all subgroup metrics.
-            * ``None``: Returns a ``{subgroup: subgroup_metric, ...}`` dict.
+            * ``None``: Returns a ``{subgroup_pair: subgroup_pair_metric, ...}`` dict.
 
     Examples
     --------
@@ -1091,7 +1091,7 @@ def false_discovery_rate(
 
             * ``'max'``: Returns the maximal value among all subgroup metrics.
             * ``'mean'``: Returns the mean over all subgroup metrics.
-            * ``None``: Returns a ``{subgroup: subgroup_metric, ...}`` dict.
+            * ``None``: Returns a ``{subgroup_pair: subgroup_pair_metric, ...}`` dict.
 
     Returns
     -------
@@ -1161,7 +1161,7 @@ class ErrorRateScorer(_ModelFairnessScorer):
 
             * ``'max'``: Returns the maximal value among all subgroup metrics.
             * ``'mean'``: Returns the mean over all subgroup metrics.
-            * ``None``: Returns a ``{subgroup: subgroup_metric, ...}`` dict.
+            * ``None``: Returns a ``{subgroup_pair: subgroup_pair_metric, ...}`` dict.
 
     Examples
     --------
@@ -1220,7 +1220,7 @@ def error_rate(
 
             * ``'max'``: Returns the maximal value among all subgroup metrics.
             * ``'mean'``: Returns the mean over all subgroup metrics.
-            * ``None``: Returns a ``{subgroup: subgroup_metric, ...}`` dict.
+            * ``None``: Returns a ``{subgroup_pair: subgroup_pair_metric, ...}`` dict.
 
     Returns
     -------
@@ -1296,7 +1296,7 @@ class EqualizedOddsScorer(_ModelFairnessScorer):
 
             * ``'max'``: Returns the maximal value among all subgroup metrics.
             * ``'mean'``: Returns the mean over all subgroup metrics.
-            * ``None``: Returns a ``{subgroup: subgroup_metric, ...}`` dict.
+            * ``None``: Returns a ``{subgroup_pair: subgroup_pair_metric, ...}`` dict.
 
     References
     ----------
@@ -1362,7 +1362,7 @@ def equalized_odds(
 
             * ``'max'``: Returns the maximal value among all subgroup metrics.
             * ``'mean'``: Returns the mean over all subgroup metrics.
-            * ``None``: Returns a ``{subgroup: subgroup_metric, ...}`` dict.
+            * ``None``: Returns a ``{subgroup_pair: subgroup_pair_metric, ...}`` dict.
 
     Returns
     -------
@@ -1438,7 +1438,7 @@ class TheilIndexScorer(_ModelFairnessScorer):
 
             * ``'max'``: Returns the maximal value among all subgroup metrics.
             * ``'mean'``: Returns the mean over all subgroup metrics.
-            * ``None``: Returns a ``{subgroup: subgroup_metric, ...}`` dict.
+            * ``None``: Returns a ``{subgroup_pair: subgroup_pair_metric, ...}`` dict.
 
     References
     ----------
@@ -1505,7 +1505,7 @@ def theil_index(
 
             * ``'max'``: Returns the maximal value among all subgroup metrics.
             * ``'mean'``: Returns the mean over all subgroup metrics.
-            * ``None``: Returns a ``{subgroup: subgroup_metric, ...}`` dict.
+            * ``None``: Returns a ``{subgroup_pair: subgroup_pair_metric, ...}`` dict.
 
     Returns
     -------

--- a/guardian_ai/fairness/metrics/model.py
+++ b/guardian_ai/fairness/metrics/model.py
@@ -111,6 +111,7 @@ def _model_metric(
 
     groups = []
     scores = []
+    visited_subgroup_pairs = set()
     # subgroup_divisions is a list of all subgroup pairs,
     # e.g. [([{'sex': 0, 'race': 0}], [{'sex': 0, 'race': 1}]), ...]
     for unpriv_group, priv_group in subgroup_divisions:
@@ -118,12 +119,13 @@ def _model_metric(
             ds_true, ds_pred, unpriv_group, priv_group
         )
 
-        score, unpriv_group_repr = _get_score_group_from_metrics(
+        score, group_repr = _get_score_group_from_metrics(
             subgroup_metrics, distance, metric, unpriv_group, priv_group, attr_idx_to_vals
         )
-
-        scores.append(score)
-        groups.append(unpriv_group_repr)
+        if (group_repr[1], group_repr[0]) not in visited_subgroup_pairs:
+            scores.append(score)
+            groups.append(group_repr)
+            visited_subgroup_pairs.add(group_repr)
 
     return reduction(groups, scores)
 

--- a/guardian_ai/fairness/metrics/utils.py
+++ b/guardian_ai/fairness/metrics/utils.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import re
 from abc import ABC, abstractmethod
 from itertools import product
+from collections import defaultdict 
 from typing import TYPE_CHECKING, Optional
 
 from guardian_ai.fairness.utils.lazy_loader import LazyLoader
@@ -139,7 +140,13 @@ class _RawReduction(_Reduction):
     display_name = "Raw"
 
     def __call__(self, groups, metrics):
-        return dict(zip(groups, metrics))
+        res = defaultdict(list)
+        for group, metric in zip(groups, metrics):
+            res[group] += [metric]
+        for group in res:
+            res[group] = sum(res[group])/len(res[group])
+        res = dict(res)
+        return res
 
 
 def _get_check_reduction(reduction):

--- a/guardian_ai/fairness/metrics/utils.py
+++ b/guardian_ai/fairness/metrics/utils.py
@@ -279,7 +279,7 @@ def _get_attr_idx_mappings(subgroups):
     return attr_vals_to_idx, attr_idx_to_vals
 
 
-def _get_one_vs_all_subgroup_divisions(subgroups):
+def _get_subgroup_divisions(subgroups):
     protected_attributes = subgroups.columns
 
     all_attr_vals = [np.unique(subgroups[attr]) for attr in protected_attributes]
@@ -314,7 +314,7 @@ def _get_check_inputs(
     _check_subgroups(subgroups)
     attr_vals_to_idx, attr_idx_to_vals = _get_attr_idx_mappings(subgroups)
 
-    subgroup_divisions = _get_one_vs_all_subgroup_divisions(subgroups)
+    subgroup_divisions = _get_subgroup_divisions(subgroups)
 
     return reduction, distance, attr_vals_to_idx, attr_idx_to_vals, subgroup_divisions
 

--- a/guardian_ai/fairness/metrics/utils.py
+++ b/guardian_ai/fairness/metrics/utils.py
@@ -322,12 +322,12 @@ def _get_score_group_from_metrics(
     metric_fn = getattr(subgroup_metrics, metric)
     score = distance(subgroup_metrics, metric_fn)
 
-    group_repr = []
+    group_repr = tuple()
     for group in [unpriv_group, priv_group]:
         cur_group_repr = tuple(
             (attr, attr_idx_to_vals[attr][idx]) for attr, idx in group[0].items()
         )
-        group_repr.append(cur_group_repr)
+        group_repr += (cur_group_repr,)
 
     return score, group_repr
 

--- a/guardian_ai/fairness/metrics/utils.py
+++ b/guardian_ai/fairness/metrics/utils.py
@@ -325,8 +325,10 @@ def _get_score_group_from_metrics(
     group_repr = tuple()
     for group in [unpriv_group, priv_group]:
         cur_group_repr = tuple(
-            (attr, attr_idx_to_vals[attr][idx]) for attr, idx in group[0].items()
+            attr_idx_to_vals[attr][idx] for attr, idx in group[0].items()
         )
+        if len(cur_group_repr) == 1:
+            cur_group_repr = cur_group_repr[0]
         group_repr += (cur_group_repr,)
 
     return score, group_repr

--- a/tests/unitary/test_fairness_metrics.py
+++ b/tests/unitary/test_fairness_metrics.py
@@ -675,98 +675,84 @@ def calibration_dataset_two_classes():
 model_scorers_two_classes_calibration_exps = {
     "model_statistical_parity_scorer": {  # male=0.5, female=0.75
         (("distance_measure", "diff"), ("reduction", None)): {
-            (("sex", "male"),): 0.25,
-            (("sex", "female"),): 0.25,
+            ("female", "male"): 0.25
         },
         (("distance_measure", "diff"), ("reduction", "max")): 0.25,
         (("distance_measure", "diff"), ("reduction", "mean")): 0.25,
         (("distance_measure", "ratio"), ("reduction", None)): {
-            (("sex", "male"),): 1.5,
-            (("sex", "female"),): 1.5,
+           ("female", "male"): 1.5
         },
         (("distance_measure", "ratio"), ("reduction", "max")): 1.5,
         (("distance_measure", "ratio"), ("reduction", "mean")): 1.5,
     },
     "true_positive_rate_scorer": {  # male=0.5, female=0.5
         (("distance_measure", "diff"), ("reduction", None)): {
-            (("sex", "male"),): 0.0,
-            (("sex", "female"),): 0.0,
+            ("female", "male"): 0.0
         },
         (("distance_measure", "diff"), ("reduction", "max")): 0.0,
         (("distance_measure", "diff"), ("reduction", "mean")): 0.0,
         (("distance_measure", "ratio"), ("reduction", None)): {
-            (("sex", "male"),): 1.0,
-            (("sex", "female"),): 1.0,
+            ("female", "male"): 1.0
         },
         (("distance_measure", "ratio"), ("reduction", "max")): 1.0,
         (("distance_measure", "ratio"), ("reduction", "mean")): 1.0,
     },
     "false_positive_rate_scorer": {  # male=0.5, female=1.0
         (("distance_measure", "diff"), ("reduction", None)): {
-            (("sex", "male"),): 0.5,
-            (("sex", "female"),): 0.5,
+            ("female", "male"): 0.5
         },
         (("distance_measure", "diff"), ("reduction", "max")): 0.5,
         (("distance_measure", "diff"), ("reduction", "mean")): 0.5,
         (("distance_measure", "ratio"), ("reduction", None)): {
-            (("sex", "male"),): 2.0,
-            (("sex", "female"),): 2.0,
+            ("female", "male"): 2.0
         },
         (("distance_measure", "ratio"), ("reduction", "max")): 2.0,
         (("distance_measure", "ratio"), ("reduction", "mean")): 2.0,
     },
     "false_negative_rate_scorer": {  # male=0.5, female=0.5
         (("distance_measure", "diff"), ("reduction", None)): {
-            (("sex", "male"),): 0.0,
-            (("sex", "female"),): 0.0,
+            ("female", "male"): 0.0
         },
         (("distance_measure", "diff"), ("reduction", "max")): 0.0,
         (("distance_measure", "diff"), ("reduction", "mean")): 0.0,
         (("distance_measure", "ratio"), ("reduction", None)): {
-            (("sex", "male"),): 1.0,
-            (("sex", "female"),): 1.0,
+            ("female", "male"): 1.0
         },
         (("distance_measure", "ratio"), ("reduction", "max")): 1.0,
         (("distance_measure", "ratio"), ("reduction", "mean")): 1.0,
     },
     "false_omission_rate_scorer": {  # male=0.67, female=1.0
         (("distance_measure", "diff"), ("reduction", None)): {
-            (("sex", "male"),): 1 / 3,
-            (("sex", "female"),): 1 / 3,
+            ("female", "male"): 1 / 3
         },
         (("distance_measure", "diff"), ("reduction", "max")): 1 / 3,
         (("distance_measure", "diff"), ("reduction", "mean")): 1 / 3,
         (("distance_measure", "ratio"), ("reduction", None)): {
-            (("sex", "male"),): 1.5,
-            (("sex", "female"),): 1.5,
+            ("female", "male"): 1.5
         },
         (("distance_measure", "ratio"), ("reduction", "max")): 1.5,
         (("distance_measure", "ratio"), ("reduction", "mean")): 1.5,
     },
     "false_discovery_rate_scorer": {  # male=0.33, female=0.67
         (("distance_measure", "diff"), ("reduction", None)): {
-            (("sex", "male"),): 1 / 3,
-            (("sex", "female"),): 1 / 3,
+            ("female", "male"): 1 / 3
         },
         (("distance_measure", "diff"), ("reduction", "max")): 1 / 3,
         (("distance_measure", "diff"), ("reduction", "mean")): 1 / 3,
         (("distance_measure", "ratio"), ("reduction", None)): {
-            (("sex", "male"),): 2.0,
-            (("sex", "female"),): 2.0,
+            ("female", "male"): 2.0
         },
         (("distance_measure", "ratio"), ("reduction", "max")): 2.0,
         (("distance_measure", "ratio"), ("reduction", "mean")): 2.0,
     },
     "error_rate_scorer": {  # male=0.5, female=0.75
         (("distance_measure", "diff"), ("reduction", None)): {
-            (("sex", "male"),): 0.25,
-            (("sex", "female"),): 0.25,
+            ("female", "male"): 0.25
         },
         (("distance_measure", "diff"), ("reduction", "max")): 0.25,
         (("distance_measure", "diff"), ("reduction", "mean")): 0.25,
         (("distance_measure", "ratio"), ("reduction", None)): {
-            (("sex", "male"),): 1.5,
-            (("sex", "female"),): 1.5,
+            ("female", "male"): 1.5
         },
         (("distance_measure", "ratio"), ("reduction", "max")): 1.5,
         (("distance_measure", "ratio"), ("reduction", "mean")): 1.5,
@@ -793,14 +779,12 @@ def test_calibration_model_scorers_two_classes(calibration_dataset_two_classes, 
 dataset_scorers_two_classes_calibration_exps = {
     "dataset_statistical_parity_scorer": {  # male=0.66, female=0.5
         (("distance_measure", "diff"), ("reduction", None)): {
-            (("sex", "male"),): 1 / 6,
-            (("sex", "female"),): 1 / 6,
+            ("female", "male"): 1 / 6
         },
         (("distance_measure", "diff"), ("reduction", "max")): 1 / 6,
         (("distance_measure", "diff"), ("reduction", "mean")): 1 / 6,
         (("distance_measure", "ratio"), ("reduction", None)): {
-            (("sex", "male"),): 4 / 3,
-            (("sex", "female"),): 4 / 3,
+            ("female", "male"): 4 / 3
         },
         (("distance_measure", "ratio"), ("reduction", "max")): 4 / 3,
         (("distance_measure", "ratio"), ("reduction", "mean")): 4 / 3,


### PR DESCRIPTION
Two minor changes in bias mitigation:

- Raw reduction has a minor bug, it should calculate the avg of scores for each group.
- one_vs_all is not the right name for our model metric. It actually computes a given metric on all subgroup pairs for a specified 'subgroups' input.